### PR TITLE
QUARKS-12 [WIP] Provide job health info

### DIFF
--- a/api/execution/src/main/java/quarks/execution/Job.java
+++ b/api/execution/src/main/java/quarks/execution/Job.java
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeoutException;
 
 /**
  * Actions and states for execution of a Quarks job.
- * <p>
+ * 
  * The interface provides the main job lifecycle control, taking on the following 
  * execution state values:
  *
@@ -31,8 +31,16 @@ import java.util.concurrent.TimeoutException;
  *      while the job is making a state transition after the client code 
  *      calls {@link #stateChange(Job.Action)}.</li>
  * <li> {@link #getNextState() Next} - The destination state while the job 
- *      is making a state transition; same as the {@link #getCurrentState() current} 
- *      state while the job state is stable (that is, not making a transition).</LI>
+ *      is making a state transition; same as the current state while 
+ *      the job state is stable (that is, not making a transition).</LI>
+ * </ul>
+ * 
+ * The interface provides access to the job nodes 
+ * {@linkplain #getHealth() health summary}, described by the following values:
+ * <ul>
+ * <li><b>HEALTHY</b>  All graph nodes in the job are healthy.</li>
+ * <li><b>UNHEALTHY</b>  At least one graph node in the job is stopped or 
+ *      stopping.</li>
  * </ul>
  */
 public interface Job {
@@ -53,20 +61,19 @@ public interface Job {
     }
 
     /**
-     * Retrieves the current state of this job.
-     *
-     * @return the current state.
+     * Enumeration for the summarized health indicator of the graph nodes.
      */
-    State getCurrentState();
-
-    /**
-     * Retrieves the next execution state when this job makes a state 
-     * transition.
-     *
-     * @return the destination state while in a state transition; 
-     *      otherwise the same as {@link #getCurrentState()}.
-     */
-    State getNextState();
+    public enum Health { 
+        /** 
+         * All graph nodes in the job are healthy.
+         */
+        HEALTHY,
+        /** 
+         * The execution of at least one graph node in the job has stopped
+         * because of an abnormal condition.
+         */
+        UNHEALTHY
+    }
 
     /**
      * Actions which trigger {@link Job.State} transitions.
@@ -85,7 +92,23 @@ public interface Job {
     }
 
     /**
-     * Initiates a {@link Job.State State} change.
+     * Retrieves the current state of this job.
+     *
+     * @return the current state.
+     */
+    State getCurrentState();
+
+    /**
+     * Retrieves the next execution state when this job makes a state 
+     * transition.
+     *
+     * @return the destination state while in a state transition; 
+     *      otherwise the same as {@link #getCurrentState()}.
+     */
+    State getNextState();
+
+    /**
+     * Initiates an execution state change.
      * 
      * @param action which triggers the state change.
      * @throws IllegalArgumentException if the job is not in an appropriate 
@@ -93,6 +116,20 @@ public interface Job {
      */
     void stateChange(Action action) throws IllegalArgumentException;
     
+    /**
+     * Returns the summarized health indicator of the graph nodes.  
+     * 
+     * @return the summarized Job node health.
+     */
+    Health getHealth();
+    
+    /**
+     * Returns the last error message caught by the current job execution.  
+     * @return the last error message or an empty string if no error has 
+     *      been caught.
+     */
+    String getLastError();
+
     /**
      * Returns the name of this job. The name may be set when the job is 
      * {@linkplain quarks.execution.Submitter#submit(java.lang.Object,com.google.gson.JsonObject) submitted}.

--- a/api/execution/src/main/java/quarks/execution/mbeans/JobMXBean.java
+++ b/api/execution/src/main/java/quarks/execution/mbeans/JobMXBean.java
@@ -15,6 +15,81 @@ public interface JobMXBean {
     String TYPE = "job";
 
     /**
+     * Enumeration for the current status of the job.
+     */
+    enum State {  
+        /** Initial state, the graph nodes are not yet initialized. */
+        CONSTRUCTED, 
+        /** All the graph nodes have been initialized. */
+        INITIALIZED,
+        /** All the graph nodes are processing data. */
+        RUNNING,
+        /** All the graph nodes are paused. */
+        PAUSED, 
+        /** All the graph nodes are closed. */
+        CLOSED;
+        
+        /**
+         * Converts from a string representation of a job status to the corresponding enumeration value.
+         * 
+         * @param state specifies a job status string value.
+         * 
+         * @return the corresponding {@code Status} enumeration value.
+         * 
+         * @throws IllegalArgumentException if the input string does not map to an enumeration value.
+         * @throws NullPointerException if the input value is null.
+         */
+        static public State fromString(String state) {
+            if (state ==  null) {
+                throw new NullPointerException("state");  
+            }
+            for (State value : State.values()) {
+                if (value.name().equals(state)) {
+                    return value;
+                }
+            }
+            throw new IllegalArgumentException(state);
+        }
+    }
+    
+    /**
+     * Enumeration for the current job health indicator.
+     */
+    enum Health {  
+        /** 
+         * All graph nodes in the job are healthy.
+         */
+        HEALTHY,
+        /** 
+         * The execution of at least one graph node in the job has stopped
+         * because of an abnormal condition.
+         */
+        UNHEALTHY;
+        
+        /**
+         * Converts from a string representation of a job health to the corresponding enumeration value.
+         * 
+         * @param health specifies a job health string value.
+         * 
+         * @return the corresponding {@code Health} enumeration value.
+         * 
+         * @throws IllegalArgumentException if the input string does not map to an enumeration value.
+         * @throws NullPointerException if the input value is null.
+         */
+        static public Health fromString(String health) {
+            if (health ==  null) {
+                throw new NullPointerException("health");  
+            }
+            for (Health value : Health.values()) {
+                if (value.name().equals(health)) {
+                    return value;
+                }
+            }
+            throw new IllegalArgumentException(health);
+        }
+    }
+
+    /**
      * Returns the identifier of the job.
      * 
      * @return the job identifier.
@@ -42,45 +117,21 @@ public interface JobMXBean {
      * @return the destination state while in a state transition.
      */
     State getNextState();
-    
+
     /**
-     * Enumeration for the current status of the job.
+     * Returns the summarized health indicator of the job.  
+     * 
+     * @return the summarized Job health.
      */
-    enum State {  
-        /** Initial state, the graph nodes are not yet initialized. */
-        CONSTRUCTED, 
-        /** All the graph nodes have been initialized. */
-        INITIALIZED,
-        /** All the graph nodes are processing data. */
-        RUNNING,
-        /** All the graph nodes are paused. */
-        PAUSED, 
-        /** All the graph nodes are closed. */
-        CLOSED;
-        
-        /**
-         * Converts from a string representation of a job status to the corresponding enumeration value.
-         * 
-         * @param state specifies a job status string value.
-         * 
-         * @return the corresponding Status enumeration value.
-         * 
-         * @throws IllegalArgumentException if the input string does not map to an enumeration value.
-         * @throws NullPointerException if the input value is null.
-         */
-        static public State fromString(String state) {
-            if (state ==  null) {
-                throw new NullPointerException("state");  
-            }
-            for (State value : State.values()) {
-                if (value.name().equals(state)) {
-                    return value;
-                }
-            }
-            throw new IllegalArgumentException(state);
-        }
-    }
-    
+    Health getHealth();
+
+    /**
+     * Returns the last error message caught by the current job execution.  
+     * @return the last error message or an empty string if no error has 
+     *      been caught.
+     */
+    String getLastError();
+
     /**
      * Takes a current snapshot of the running graph and returns it in JSON format.
      * <p>

--- a/providers/direct/src/test/java/quarks/test/providers/direct/DirectJobTest.java
+++ b/providers/direct/src/test/java/quarks/test/providers/direct/DirectJobTest.java
@@ -75,8 +75,13 @@ public class DirectJobTest extends TopologyAbstractTest implements DirectTestSet
 
         Job job = awaitCompleteExecution(t);
         assertEquals("job.getCurrentState() must be RUNNING", Job.State.RUNNING, job.getCurrentState());
+        assertEquals("job.getCurrentState() must be HEALTHY", Job.Health.HEALTHY, job.getHealth());
+        assertEquals("", job.getLastError());
+
         job.stateChange(Job.Action.CLOSE);
         assertEquals("job.getCurrentState() must be CLOSED", Job.State.CLOSED, job.getCurrentState());
+        assertEquals("job.getCurrentState() must be HEALTHY", Job.Health.HEALTHY, job.getHealth());
+        assertEquals("", job.getLastError());
     }
 
     @Test
@@ -88,8 +93,12 @@ public class DirectJobTest extends TopologyAbstractTest implements DirectTestSet
 
         Job job = awaitCompleteExecution(t);
         assertEquals("job.getCurrentState() must be RUNNING", Job.State.RUNNING, job.getCurrentState());
+        assertEquals("job.getCurrentState() must be HEALTHY", Job.Health.HEALTHY, job.getHealth());
+        assertEquals("", job.getLastError());
         job.stateChange(Job.Action.CLOSE);
         assertEquals("job.getCurrentState() must be CLOSED", Job.State.CLOSED, job.getCurrentState());
+        assertEquals("job.getCurrentState() must be HEALTHY", Job.Health.HEALTHY, job.getHealth());
+        assertEquals("", job.getLastError());
     }
 
     @Test
@@ -109,8 +118,12 @@ public class DirectJobTest extends TopologyAbstractTest implements DirectTestSet
         Thread.sleep(1500); // wait for numTuples visibility 
         assertEquals(NUM_TUPLES, numTuples.get());
         assertEquals("job.getCurrentState() must be RUNNING", Job.State.RUNNING, job.getCurrentState());
+        assertEquals("job.getCurrentState() must be HEALTHY", Job.Health.HEALTHY, job.getHealth());
+        assertEquals("", job.getLastError());
         job.stateChange(Job.Action.CLOSE);
         assertEquals("job.getCurrentState() must be CLOSED", Job.State.CLOSED, job.getCurrentState());
+        assertEquals("job.getCurrentState() must be HEALTHY", Job.Health.HEALTHY, job.getHealth());
+        assertEquals("", job.getLastError());
     }
 
     @Test
@@ -154,7 +167,9 @@ public class DirectJobTest extends TopologyAbstractTest implements DirectTestSet
         Thread.sleep(TimeUnit.SECONDS.toMillis(1));
         int tupleCount = n.get(); 
         assertTrue("Expected more tuples than "+ tupleCount, tupleCount > 0); // At least one tuple was processed
-        
+        assertEquals(Job.Health.HEALTHY, job.getHealth());
+        assertEquals("", job.getLastError());
+
         // Changing the period cancels the source's task and schedules new one
         src.setPeriod(100); 
 
@@ -165,6 +180,8 @@ public class DirectJobTest extends TopologyAbstractTest implements DirectTestSet
 
         job.stateChange(Job.Action.CLOSE);
         assertEquals(Job.State.CLOSED, job.getCurrentState());
+        assertEquals(Job.Health.HEALTHY, job.getHealth());
+        assertEquals("", job.getLastError());
     }
 
     @Test
@@ -177,10 +194,14 @@ public class DirectJobTest extends TopologyAbstractTest implements DirectTestSet
         Future<Job> fj = ((DirectProvider)getTopologyProvider()).submit(t);
         Job job = fj.get();
         assertEquals(Job.State.RUNNING, job.getCurrentState());
+        assertEquals(Job.Health.HEALTHY, job.getHealth());
+        assertEquals("", job.getLastError());
         Thread.sleep(TimeUnit.SECONDS.toMillis(2));
         assertTrue(n.get() > 0); // At least one tuple was processed
         job.stateChange(Job.Action.CLOSE);
         assertEquals(Job.State.CLOSED, job.getCurrentState());
+        assertEquals(Job.Health.HEALTHY, job.getHealth());
+        assertEquals("", job.getLastError());
     }
 
     @Test(expected = TimeoutException.class)
@@ -198,6 +219,8 @@ public class DirectJobTest extends TopologyAbstractTest implements DirectTestSet
         } finally {
             assertTrue(n.get() > 0); // At least one tuple was processed
             assertEquals(Job.State.RUNNING, job.getCurrentState());
+            assertEquals(Job.Health.HEALTHY, job.getHealth());
+            assertEquals("", job.getLastError());
         }
     }
 
@@ -216,6 +239,8 @@ public class DirectJobTest extends TopologyAbstractTest implements DirectTestSet
         } finally {
             // RUNNING even though execution error 
             assertEquals(Job.State.RUNNING, job.getCurrentState());
+            assertEquals(Job.Health.UNHEALTHY, job.getHealth());
+            assertEquals("java.lang.RuntimeException: Expected Test Exception", job.getLastError());
         }
     }
 
@@ -234,6 +259,8 @@ public class DirectJobTest extends TopologyAbstractTest implements DirectTestSet
         } finally {
             // RUNNING even though execution error 
             assertEquals(Job.State.RUNNING, job.getCurrentState());
+            assertEquals(Job.Health.UNHEALTHY, job.getHealth());
+            assertEquals("java.lang.RuntimeException: Expected Test Exception", job.getLastError());
         }
     }
 

--- a/runtime/etiao/src/main/java/quarks/runtime/etiao/EtiaoJob.java
+++ b/runtime/etiao/src/main/java/quarks/runtime/etiao/EtiaoJob.java
@@ -190,4 +190,12 @@ public class EtiaoJob extends AbstractGraphJob implements JobContext {
         if (jobs != null)
             jobs.updateJob(this);
     }
+    
+    void updateHealth(Throwable t) {
+        if (t != null) {
+            setHealth(Health.UNHEALTHY);
+            setLastError(t.getMessage());
+        }
+        updateRegistry();
+    }
 }

--- a/runtime/etiao/src/main/java/quarks/runtime/etiao/Executable.java
+++ b/runtime/etiao/src/main/java/quarks/runtime/etiao/Executable.java
@@ -81,6 +81,7 @@ public class Executable implements RuntimeServices {
             public void accept(Object source, Throwable t) {
                 if (t != null) {
                     Executable.this.setLastError(t);
+                    job.updateHealth(t);
                     cleanup();
                 }
                 else if (job.getCurrentState() == Job.State.RUNNING &&

--- a/runtime/etiao/src/main/java/quarks/runtime/etiao/mbeans/EtiaoJobBean.java
+++ b/runtime/etiao/src/main/java/quarks/runtime/etiao/mbeans/EtiaoJobBean.java
@@ -12,7 +12,7 @@ import quarks.runtime.etiao.EtiaoJob;
 import quarks.runtime.etiao.graph.model.GraphType;
 
 /**
- * Implementation of a JMX control interface for a job.
+ * Implementation of a JMX control interface for the {@code EtiaoJob}.
  */
 public class EtiaoJobBean implements JobMXBean {
     private final EtiaoJob job;
@@ -44,5 +44,15 @@ public class EtiaoJobBean implements JobMXBean {
     public String graphSnapshot() {
         Gson gson = new GsonBuilder().create();
         return gson.toJson(new GraphType(job.graph()));
+    }
+
+    @Override
+    public Health getHealth() {
+        return Health.fromString(job.getHealth().name());
+    }
+
+    @Override
+    public String getLastError() {
+        return job.getLastError();
     }
 }

--- a/samples/topology/src/main/java/quarks/samples/topology/DevelopmentSampleJobMXBean.java
+++ b/samples/topology/src/main/java/quarks/samples/topology/DevelopmentSampleJobMXBean.java
@@ -41,7 +41,7 @@ public class DevelopmentSampleJobMXBean {
         StringBuffer sbuf = new StringBuffer();
         sbuf.append(DevelopmentProvider.JMX_DOMAIN);
         sbuf.append(":interface=");
-        sbuf.append(ObjectName.quote("quarks.graph.execution.mbeans.JobMXBean"));
+        sbuf.append(ObjectName.quote("quarks.execution.mbeans.JobMXBean"));
         sbuf.append(",type=");
         sbuf.append(ObjectName.quote("job"));
         sbuf.append(",*");
@@ -60,8 +60,12 @@ public class DevelopmentSampleJobMXBean {
         	String jobName = (String) mBeanServer.getAttribute(objectName, "Name");
         	String jobCurState = (String) mBeanServer.getAttribute(objectName, "CurrentState");
         	String jobNextState = (String) mBeanServer.getAttribute(objectName, "NextState");
+            String jobHealth = (String) mBeanServer.getAttribute(objectName, "Health");
+            String jobLastError = (String) mBeanServer.getAttribute(objectName, "LastError");
         	
-        	System.out.println("Found a job with JobId: " + jobId + " Name: " + jobName + " CurrentState: " + jobCurState + " NextState: " + jobNextState);
+        	System.out.println("Found a job with JobId: " + jobId + " Name: " + jobName + 
+                    " CurrentState: " + jobCurState + " NextState: " + jobNextState + 
+                    " Health: " + jobHealth + " LastError: \"" + jobLastError + "\"");
         }
     }
 }

--- a/samples/topology/src/main/java/quarks/samples/topology/JobEventsSample.java
+++ b/samples/topology/src/main/java/quarks/samples/topology/JobEventsSample.java
@@ -133,14 +133,18 @@ public class JobEventsSample {
      * @return the wrapped data
      */
     static JsonObject wrap(JobRegistryService.EventType evType, Job job) {
-        JsonObject jo = new JsonObject();
-        jo.addProperty("time", (Number)System.currentTimeMillis());
-        jo.addProperty("event", evType.toString());
-        jo.addProperty("jobId", job.getId());
-        jo.addProperty("jobName", job.getName());
-        jo.addProperty("jobState", job.getCurrentState().toString());
-        jo.addProperty("jobNextState", job.getNextState().toString());
-        return jo;
+        JsonObject value = new JsonObject();
+        value.addProperty("time", (Number)System.currentTimeMillis());
+        value.addProperty("event", evType.toString());
+        JsonObject obj = new JsonObject();
+        obj.addProperty("id", job.getId());
+        obj.addProperty("name", job.getName());
+        obj.addProperty("state", job.getCurrentState().toString());
+        obj.addProperty("nextState", job.getNextState().toString());
+        obj.addProperty("health", job.getHealth().toString());
+        obj.addProperty("lastError", job.getLastError());
+        value.add("job", obj);
+        return value;
     }
 
     private DirectProvider provider() {

--- a/spi/graph/src/main/java/quarks/graph/spi/execution/AbstractGraphJob.java
+++ b/spi/graph/src/main/java/quarks/graph/spi/execution/AbstractGraphJob.java
@@ -13,10 +13,14 @@ import quarks.execution.Job;
 public abstract class AbstractGraphJob implements Job {
     private State currentState;
     private State nextState;
-    
+    private Health health;
+    private String lastError;
+
     protected AbstractGraphJob() {
         this.currentState = State.CONSTRUCTED;
         this.nextState = currentState;
+        this.health = Health.HEALTHY;
+        this.lastError = new String();
     }
 
     @Override
@@ -32,6 +36,16 @@ public abstract class AbstractGraphJob implements Job {
     @Override
     public abstract void stateChange(Action action);
     
+    @Override
+    public Health getHealth() {
+        return health;
+    }
+
+    @Override
+    public String getLastError() {
+        return lastError;
+    }
+
     protected synchronized boolean inTransition() {
         return getNextState() != getCurrentState();
     }
@@ -44,5 +58,13 @@ public abstract class AbstractGraphJob implements Job {
         if (inTransition()) {
             currentState = nextState;
         }
+    }
+    
+    protected void setHealth(Health value) {
+        this.health = value;
+    }
+    
+    protected void setLastError(String value) {
+        this.lastError = value;
     }
 }


### PR DESCRIPTION
Contains updates to the Job interface and runtime implementation:
 - Job.Health enum: HEALTHY, UNHEALTHY 
 - Job.getHealth() - current health value
 - Job.getLastError() - message of the exception which caused the job to become unhealthy