### PR TITLE
Change IBM copyrights to required ASF branding for Javadoc

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -295,9 +295,9 @@
         </fileset>
       </classpath>
 
-       <doctitle>Quarks v${quarks.version}</doctitle>
-       <footer><![CDATA[<a href="http://quarks-edge.github.io">quarks-edge community @ github.com</a>]]></footer>
-       <bottom>Copyright IBM 2015,2016 - ${commithash}-${DSTAMP}-${TSTAMP}</bottom>
+       <doctitle>Apache Quarks (incubating) v${quarks.version}</doctitle>
+       <footer><![CDATA[<a href="http://quarks.incubator.apache.org">Apache Quarks (incubating)</a>]]></footer>
+       <bottom>Copyright &amp;copy; 2016 The Apache Software Foundation. All Rights Reserved - ${commithash}-${DSTAMP}-${TSTAMP}</bottom>
        <group title="Quarks API" packages="quarks.execution,quarks.function,quarks.topology,quarks.topology.*,quarks.execution.*"/>
        <group title="Quarks Providers" packages="quarks.providers.*"/>
        <group title="Quarks Connectors" packages="quarks.connectors.*"/>

--- a/quarks_overview.html
+++ b/quarks_overview.html
@@ -1,6 +1,11 @@
 <body>
 Quarks provides an programming model and runtime for executing streaming
-analytics at the <i>edge</i>
+analytics at the <i>edge</i>.
+<P>
+<em>
+Apache Quarks is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by Apache Incubator PMC. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
+</em>
+</P>
 <H1>Quarks v0.4</H1>
 <OL>
 <LI><a href="#overview">Overview</A></LI>


### PR DESCRIPTION
Include incubation disclaimer in the Javadoc overview as the incubator branding indicates documentation must have the disclaimer.

http://incubator.apache.org/guides/branding.html