### PR TITLE
QUARKS-13: Start over Quarks when the JVM crashes (Linux)

### DIFF
--- a/samples/topology/src/main/java/quarks/samples/topology/TerminateAfterNTuples.java
+++ b/samples/topology/src/main/java/quarks/samples/topology/TerminateAfterNTuples.java
@@ -1,0 +1,67 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package quarks.samples.topology;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import quarks.providers.direct.DirectProvider;
+import quarks.topology.TStream;
+import quarks.topology.Topology;
+
+/**
+ * This application simulates a crash and terminates the JVM after processing
+ * a preset number of tuples. This application is used in conjunction with a 
+ * monitoring script to demonstrate the restart of a JVM which has terminated
+ * because of a Quarks application crash.
+ */
+public class TerminateAfterNTuples {
+    /** The application will terminate the JVM after this tuple count */
+    public final static int TERMINATE_COUNT = 15;
+    
+    public static void main(String[] args) throws Exception {
+
+        DirectProvider tp = new DirectProvider();
+
+        Topology t = tp.newTopology("PeriodicSource");
+
+        // Since this is the Direct provider the graph can access
+        // objects created while the topology is being defined
+        // (in this case the Random object r).
+        Random r = new Random();
+        TStream<Double> gaussian = t.poll(() -> r.nextGaussian(), 1, TimeUnit.SECONDS);
+
+        // Program termination
+        AtomicInteger count = new AtomicInteger(0);
+        gaussian = gaussian.peek(g -> {
+            if (count.incrementAndGet() >= TERMINATE_COUNT) {
+                System.err.println("The JVM terminates after processing " + 
+                        TERMINATE_COUNT + " tuples");
+                System.exit(1);
+            }
+        });
+
+        // Peek at the value on the Stream printing it to System.out
+        gaussian = gaussian.peek(g -> System.out.println("R:" + g));
+
+        tp.submit(t);
+    }
+}

--- a/scripts/cron/README
+++ b/scripts/cron/README
@@ -1,0 +1,38 @@
+Script for restarting Quarks if the JVM crashes
+
+The startapp.sh script is setup to run as a cron job every minute in order
+to monitor a JVM running a Quarks application and restart Quarks if the 
+JVM crashes. The script checks whether the pid of the JVM indicates
+a process which is still running.  If the pid is not there, it executes the 
+command to start the application in the first place.
+
+The JVM's standard output and standard error are written to the directory 
+passed as a command line argument for the script. The script also saves the
+process id (pid) of the JVM in a file.  If the pid file already exists and 
+contains the id of a running process, then the script will not start Quarks.
+
+The script is currently setup to execute the quarks.samples.topology.Terminated
+sample, which throws an exception after processing a preset number of 
+tuples.
+
+The crontab entry file startapp.cron contains information which cron uses to
+schedule the job. 
+
+To setup the script to run as a cron job:
+
+1. Edit the startapp.cron file:
+ - Set the QUARKS environment variable to point to your quarks installation,
+   for example: QUARKS=/home/your_userid/quarks-release/quarks/java8
+ - Make sure java is in the path; cron provides a default PATH environment 
+   variable which is probably different from the one you use for development.
+
+2. Install startapp.cron: 
+
+$ crontab ./startapp.cron
+
+   Note: if you wish to have your ~/.profile executed you must explicitly
+   do so in the crontab entry or in a script called by the entry.
+
+3. To remove the current crontab entries:
+
+$ crontab -r

--- a/scripts/cron/README
+++ b/scripts/cron/README
@@ -1,38 +1,30 @@
-Script for restarting Quarks if the JVM crashes
+Restarting Quarks if the JVM crashes
 
-The startapp.sh script is setup to run as a cron job every minute in order
+The startapp.sh script can be setup to run as a cron job every minute in order
 to monitor a JVM running a Quarks application and restart Quarks if the 
 JVM crashes. The script checks whether the pid of the JVM indicates
 a process which is still running.  If the pid is not there, it executes the 
 command to start the application in the first place.
 
-The JVM's standard output and standard error are written to the directory 
-passed as a command line argument for the script. The script also saves the
-process id (pid) of the JVM in a file.  If the pid file already exists and 
-contains the id of a running process, then the script will not start Quarks.
+A crontab entry file contains information which cron uses to schedule the job.
+The sample startapp.cron file is configured to execute the 
+quarks.samples.topology.Terminated sample application, which terminates the 
+JVM after processing a preset number of tuples.
 
-The script is currently setup to execute the quarks.samples.topology.Terminated
-sample, which throws an exception after processing a preset number of 
-tuples.
-
-The crontab entry file startapp.cron contains information which cron uses to
-schedule the job. 
-
-To setup the script to run as a cron job:
+To setup cron to restart quarks.samples.topology.Terminated every minute:
 
 1. Edit the startapp.cron file:
- - Set the QUARKS environment variable to point to your quarks installation,
-   for example: QUARKS=/home/your_userid/quarks-release/quarks/java8
- - Make sure java is in the path; cron provides a default PATH environment 
-   variable which is probably different from the one you use for development.
+   - Set the QUARKS environment variable to point to your quarks installation,
+     for example: QUARKS=/home/your_userid/quarks-release/quarks/java8
+   - Set JAVA_HOME to point to your Java install directory. 
 
-2. Install startapp.cron: 
+2. Install startapp.cron:
 
-$ crontab ./startapp.cron
+   $ crontab ./startapp.cron
 
    Note: if you wish to have your ~/.profile executed you must explicitly
    do so in the crontab entry or in a script called by the entry.
 
 3. To remove the current crontab entries:
 
-$ crontab -r
+   $ crontab -r

--- a/scripts/cron/startapp.cron
+++ b/scripts/cron/startapp.cron
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Crontab file which contains settings for scheduling the execution of a 
+# monitoring script every minute using cron.
+#
+# You must set the QUARKS environment variable to point to your Quarks 
+# installation:
+# QUARKS=/home/your_userid/quarks/java8
+#
+# Make sure that java is in the PATH environment used by cron:
+# PATH=/opt/my_java/bin:$PATH
+
+* * * * * $QUARKS/scripts/cron/startapp.sh /tmp >> /tmp/quarks-cron.log

--- a/scripts/cron/startapp.cron
+++ b/scripts/cron/startapp.cron
@@ -21,7 +21,7 @@
 # installation:
 # QUARKS=/home/your_userid/quarks/java8
 #
-# Make sure that java is in the PATH environment used by cron:
-# PATH=/opt/my_java/bin:$PATH
+# Make sure that JAVA_HOME is set in the environment used by cron:
+# JAVA_HOME=/usr/lib/jvm/jre
 
-* * * * * $QUARKS/scripts/cron/startapp.sh /tmp >> /tmp/quarks-cron.log
+* * * * * $QUARKS/scripts/cron/startapp.sh $QUARKS/samples/lib/quarks.samples.topology.jar quarks.samples.topology.TerminateAfterNTuples /tmp >> /tmp/quarks-cron.log

--- a/scripts/cron/startapp.sh
+++ b/scripts/cron/startapp.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[ ! -n "${QUARKS:-}" ] && QUARKS=../..
+
+#
+# Application name identifies the running process.  For the scope of this
+# script it is also the name of the main application class.
+#
+APP=TerminateAfterNTuples
+
+#
+# Command to start the application.
+#
+COMMAND="java -cp ${QUARKS}/samples/lib/quarks.samples.topology.jar \
+quarks.samples.topology.${APP}"
+
+
+_usage() {
+  echo -e "Usage: ${0} [dir] \n\
+  Runs an application while saving its stdout to dir/${APP}.out, its stderr to dir/${APP}.err, and its process id to dir/${APP}.pid.\n\
+  \n\
+  This script starts the application only if it cannot find its pid. If the process id indicated by dir/${APP}.pid exists, then the script will not start the application.\n\
+  \n\
+  If dir is not specified, then the stdout, stderr, and pid files are saved into the current directory.\n\
+"
+}
+
+# _get_pid program [pidfile]
+# Set $pid to pids from /tmp* for {program}.
+# $pid should be declared local in the caller.
+_get_pid() {
+  local base=${1##*/}
+  local pid_file=${2:-/tmp/$base.pid}
+
+  pid=
+  if [ -f "$pid_file" ] ; then
+    local p
+
+    [ ! -r "$pid_file" ] && return 1 # "Cannot access pid file"
+
+    p=$(cat "$pid_file")
+    [ -z "${p//[0-9]/}" ] && [ -d "/proc/$p" ] && pid="$p"
+    if [ -n "$pid" ]; then
+        return 0
+    fi
+    return 2 # "Program is not running but pid file exists"
+  fi
+  return 3 # "Program pid file does not exist"
+}
+
+# _readlink path
+# Output the full path, replacement for readlink -f
+_readlink() {
+  (
+  pushd ${1%/*} > /dev/null 2>&1
+  echo $PWD/${1##*/}
+  popd > /dev/null 2>&1
+  )
+}
+
+# _dirname path
+# Get the directory name, replacement for dirname.
+_dirname() {
+  echo ${1%/*}
+}
+
+_error() {
+  echo $1; exit 1
+}
+
+
+if [ "${1:-.}" == "--help" ]; then
+  _usage
+  exit 1
+fi
+
+out_dir=${1:-.}
+
+if [[ ! -d ${out_dir} || ${out_dir:0:1} != '/' ]]; then
+  ## out_dir as absolute path
+  out_dir=$(_readlink ${out_dir})
+  out_dir=$(_dirname ${out_dir})
+fi
+
+pid_file=${out_dir}/${APP}.pid
+out_file=${out_dir}/${APP}.out
+err_file=${out_dir}/${APP}.err
+pid=
+
+_get_pid $APP $pid_file
+RC="$?"
+[ $RC == "1" ] && _error "Cannot access pid file $pid_file"
+
+if [ -z "$pid" ]; then
+  ${COMMAND} >> $out_file 2>> $err_file &
+  pid="$!"
+  echo $pid >| $pid_file
+  echo -e "The program was restarted with command:\n\
+${COMMAND}\n\
+Process id: $pid"
+else
+  echo "The program's process id is $pid"
+fi

--- a/scripts/cron/startapp.sh
+++ b/scripts/cron/startapp.sh
@@ -16,28 +16,17 @@
 # limitations under the License.
 #
 
-[ ! -n "${QUARKS:-}" ] && QUARKS=../..
-
-#
-# Application name identifies the running process.  For the scope of this
-# script it is also the name of the main application class.
-#
-APP=TerminateAfterNTuples
-
-#
-# Command to start the application.
-#
-COMMAND="java -cp ${QUARKS}/samples/lib/quarks.samples.topology.jar \
-quarks.samples.topology.${APP}"
-
-
 _usage() {
-  echo -e "Usage: ${0} [dir] \n\
-  Runs an application while saving its stdout to dir/${APP}.out, its stderr to dir/${APP}.err, and its process id to dir/${APP}.pid.\n\
-  \n\
-  This script starts the application only if it cannot find its pid. If the process id indicated by dir/${APP}.pid exists, then the script will not start the application.\n\
-  \n\
-  If dir is not specified, then the stdout, stderr, and pid files are saved into the current directory.\n\
+  echo -e "Usage: ${0} {classpath} {mainclass} [dir]\n\n\
+Runs a Java application while saving its stdout to dir/mainclass.out, its stderr to dir/mainclass.err, and its process id to dir/mainclass.pid.\n\
+\n\
+This script starts a Java application only if it cannot find its pid. If the process id specified by dir/mainclass.pid exists, then the script will not start the application.\n\
+\n\
+    classpath The application's class path.\n\
+    classname The name of the class to be launched.\n\
+    dir       The directory where the process stdout, stderr and pid files are\n\
+              written. If dir is not specified, then the files are saved into\n\
+              the current directory.\n\
 "
 }
 
@@ -85,12 +74,21 @@ _error() {
 }
 
 
-if [ "${1:-.}" == "--help" ]; then
+## Main script
+[ ! -n "${QUARKS:-}" ] && QUARKS=../..
+[ ! -n "${JAVA_HOME:-}" ] && _error "JAVA_HOME must be set"
+
+if [ $# -lt 2 ]; then
   _usage
   exit 1
 fi
 
-out_dir=${1:-.}
+classpath=${1}
+main_class=${2}
+out_dir=${3:-.}
+
+# Command to start the application.
+command="${JAVA_HOME}/bin/java -cp ${classpath} ${main_class}"
 
 if [[ ! -d ${out_dir} || ${out_dir:0:1} != '/' ]]; then
   ## out_dir as absolute path
@@ -98,21 +96,21 @@ if [[ ! -d ${out_dir} || ${out_dir:0:1} != '/' ]]; then
   out_dir=$(_dirname ${out_dir})
 fi
 
-pid_file=${out_dir}/${APP}.pid
-out_file=${out_dir}/${APP}.out
-err_file=${out_dir}/${APP}.err
+pid_file=${out_dir}/${main_class}.pid
+out_file=${out_dir}/${main_class}.out
+err_file=${out_dir}/${main_class}.err
 pid=
 
-_get_pid $APP $pid_file
+_get_pid $main_class $pid_file
 RC="$?"
 [ $RC == "1" ] && _error "Cannot access pid file $pid_file"
 
 if [ -z "$pid" ]; then
-  ${COMMAND} >> $out_file 2>> $err_file &
+  $command >> $out_file 2>> $err_file &
   pid="$!"
   echo $pid >| $pid_file
   echo -e "The program was restarted with command:\n\
-${COMMAND}\n\
+${command}\n\
 Process id: $pid"
 else
   echo "The program's process id is $pid"


### PR DESCRIPTION
Simple mechanism to restart a Quarks application if the JVM running Quarks terminates unexpectedly:
 - Sample application which simulates a JVM crash after processing N tuples
 - Script which checks whether the Quarks JVM is still running, otherwise it restarts the Quarks sample app
 - Cron entry which runs the script every mnute
 - Readme providing setup instructions