### PR TITLE
QUARKS-53 changed light grey tag color

### DIFF
--- a/console/servlets/webapp_content/js/ext/d3.legend.js
+++ b/console/servlets/webapp_content/js/ext/d3.legend.js
@@ -89,7 +89,7 @@ d3.legend = function(g, chartSvg, pItems, legendTitle) {
         .attr("width", 10)                          
         .attr("height", 8)
         .style("fill",function(d) {
-        	return d.value.color
+        	return d.value.color === "#c7c7c7" ? "#008080" : d.value.color;
         	})
         .style("stroke", "none")
         .style("fill-opacity", legendOpacity);

--- a/console/servlets/webapp_content/js/graph.js
+++ b/console/servlets/webapp_content/js/graph.js
@@ -70,8 +70,8 @@ getFormattedTagLegend = function(tArray) {
 			obj.fill = MULTIPLE_TAGS_COLOR;
 			obj.stroke = MULTIPLE_TAGS_COLOR;
 		} else {
-			obj.fill = color20(t);
-			obj.stroke = color20(t);
+			obj.fill = color20(t) === "#c7c7c7" ? "#008080" : color20(t);
+			obj.stroke = color20(t) === "#c7c7c7" ? "#008080" : color20(t);
 		}
 		items.push(obj);
 	});

--- a/console/servlets/webapp_content/js/index.js
+++ b/console/servlets/webapp_content/js/index.js
@@ -491,7 +491,8 @@ var renderGraph = function(jobId, counterMetrics, bIsNewJob) {
  
   					if (matchedTags.length > 0) {
   						if (matchedTags.length === 1) {
-  							return d.color = color20(streamsTags[matchedTags[0]]);
+  							var color = color20(streamsTags[matchedTags[0]]);
+  							return d.color =  color === "#c7c7c7" ? "#008080" : color;
   						} else {
   							// more than one tag is on this stream
   							return d.color = MULTIPLE_TAGS_COLOR;	


### PR DESCRIPTION
Currently the code that colors the stream tags and the legend for the stream tags uses a default color range called color20, part of the d3 library.  One of the colors in that range is a light grey that looks like the links that do not have stream tags.  I replaced that color with a teal color in the graph and the legend