### PR TITLE
[QUARKS-173] add load balanced parallel()

### DIFF
--- a/api/topology/src/main/java/quarks/topology/plumbing/LoadBalancedSplitter.java
+++ b/api/topology/src/main/java/quarks/topology/plumbing/LoadBalancedSplitter.java
@@ -1,0 +1,90 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+package quarks.topology.plumbing;
+
+import java.util.Arrays;
+import java.util.concurrent.Semaphore;
+
+import quarks.function.ToIntFunction;
+import quarks.topology.TStream;
+
+/**
+ * A Load Balanced Splitter function.
+ * <P>
+ * This is intended to be used as an argument to {@link TStream#split(int, ToIntFunction)}.
+ * The splitter maintains state for {@code numChannels} splitter channels,
+ * tracking whether a channel is busy or free.
+ * <P></P>
+ * {@link #applyAsInt(Object) applyAsInt} awaits a free channel, marks
+ * the channel as busy, and forwards the tuple to the channel.  The end
+ * of the channel's pipeline must call {@link #channelDone(int)} to
+ * signal that the channel is free.
+ * </P>
+ *
+ * @param <T> Tuple type.
+ * @see PlumbingStreams#parallelBalanced(TStream, int, quarks.function.BiFunction) parallelBalanced
+ */
+public class LoadBalancedSplitter<T> implements ToIntFunction<T> {
+  private static final long serialVersionUID = 1L;
+  private final Semaphore gate;
+  private final boolean[] chBusy;
+  
+  /**
+   * Create a new splitter.
+   * @param numChannels the number of splitter channels
+   */
+  public LoadBalancedSplitter(int numChannels) {
+    if (numChannels < 1)
+      throw new IllegalArgumentException("numChannels");
+    chBusy = new boolean[numChannels];
+    Arrays.fill(chBusy, false);
+    gate = new Semaphore(numChannels);
+  }
+  
+  /**
+   * Signal that the channel is done processing the splitter supplied tuple.
+   * @param channel the 0-based channel number
+   */
+  public synchronized void channelDone(int channel) {
+    if (!chBusy[channel])
+      throw new IllegalStateException("channel "+channel+" is not busy");
+    chBusy[channel] = false;
+    gate.release();
+  }
+  
+  @Override
+  public int applyAsInt(T value) {
+    try {
+      gate.acquire();
+      synchronized(this) {
+        for (int ch = 0; ch < chBusy.length; ch++) {
+          if (!chBusy[ch]) {
+            chBusy[ch] = true;
+            return ch;
+          }
+        }
+        throw new IllegalStateException("internal error");
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted", e);
+    }
+  }
+
+}

--- a/api/topology/src/test/java/quarks/test/topology/PlumbingTest.java
+++ b/api/topology/src/test/java/quarks/test/topology/PlumbingTest.java
@@ -336,8 +336,8 @@ public abstract class PlumbingTest extends TopologyAbstractTest {
             int cnt = 0;
             System.out.println("combiner: "+list);
             for(JsonObject jo : list) {
-              assertEquals(cnt++, jo.getAsJsonPrimitive("channel").getAsInt());
-              sum += jo.getAsJsonPrimitive("result").getAsInt();
+              assertEquals(cnt++, jo.get("channel").getAsInt());
+              sum += jo.get("result").getAsInt();
             }
             return sum;
         };
@@ -391,8 +391,8 @@ public abstract class PlumbingTest extends TopologyAbstractTest {
             int cnt = 0;
             System.out.println("combiner: "+list);
             for(JsonObject jo : list) {
-              assertEquals(cnt++, jo.getAsJsonPrimitive("channel").getAsInt());
-              sum += jo.getAsJsonPrimitive("result").getAsInt();
+              assertEquals(cnt++, jo.get("channel").getAsInt());
+              sum += jo.get("result").getAsInt();
             }
             return sum;
         };
@@ -488,8 +488,8 @@ public abstract class PlumbingTest extends TopologyAbstractTest {
         
         TStream<JsonObject> result = PlumbingStreams.parallelMap(values, width, splitter, mapper).tag("result");
         TStream<Integer> result2 = result.map(jo -> {
-            int r = jo.getAsJsonPrimitive("result").getAsInt();
-            assertEquals(splitter.applyAsInt(r), jo.getAsJsonPrimitive("channel").getAsInt());
+            int r = jo.get("result").getAsInt();
+            assertEquals(splitter.applyAsInt(r), jo.get("channel").getAsInt());
             return r;
           });
         
@@ -531,8 +531,8 @@ public abstract class PlumbingTest extends TopologyAbstractTest {
         
         TStream<JsonObject> result = PlumbingStreams.parallel(values, width, splitter, pipeline).tag("result");
         TStream<Integer> result2 = result.map(jo -> {
-            int r = jo.getAsJsonPrimitive("result").getAsInt();
-            assertEquals(splitter.applyAsInt(r), jo.getAsJsonPrimitive("channel").getAsInt());
+            int r = jo.get("result").getAsInt();
+            assertEquals(splitter.applyAsInt(r), jo.get("channel").getAsInt());
             return r;
           });
         
@@ -568,9 +568,9 @@ public abstract class PlumbingTest extends TopologyAbstractTest {
         Topology top = newTopology("testParallelBalanced");
         
         // arrange for even channels to process ~2x as many as odd channels.
-        BiFunction<TStream<Integer>,Integer,TStream<JsonObject>> pipeline = 
+        BiFunction<TStream<Integer>,Integer,TStream<JsonObject>> pipeline =
             (stream,ch) -> {
-              long delay = (ch % 2 == 0) ? 10 : 20; 
+              long delay = (ch % 2 == 0) ? 10 : 20;
               return stream.map(fakeAnalytic(ch, delay, TimeUnit.MILLISECONDS));
             };
         
@@ -587,8 +587,8 @@ public abstract class PlumbingTest extends TopologyAbstractTest {
         
         TStream<JsonObject> result = PlumbingStreams.parallelBalanced(values, width, pipeline).tag("result");
         TStream<Integer> result2 = result.map(jo -> {
-            int r = jo.getAsJsonPrimitive("result").getAsInt();
-            int ch = jo.getAsJsonPrimitive("channel").getAsInt();
+            int r = jo.get("result").getAsInt();
+            int ch = jo.get("channel").getAsInt();
             chCounts[ch].incrementAndGet();
             return r;
           });
@@ -638,7 +638,7 @@ public abstract class PlumbingTest extends TopologyAbstractTest {
 //        
 //        int width = 5;
 //        // ToIntFunction<Integer> splitter = tuple -> tuple % width;
-//        ToIntFunction<JsonObject> splitter = jo -> jo.getAsJsonPrimitive("result").getAsInt() % width;
+//        ToIntFunction<JsonObject> splitter = jo -> jo.get("result").getAsInt() % width;
 //        
 //        Integer[] resultTuples = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
 //        TStream<Integer> values = top.of(resultTuples);
@@ -653,15 +653,15 @@ public abstract class PlumbingTest extends TopologyAbstractTest {
 //        TStream<JsonObject> result = PlumbingStreams.parallel(inStream, width, splitter, pipeline).tag("result");
 //        TStream<Integer> result2 = result.map(jo -> {
 //            jo.addProperty("exitParallelMsec", System.currentTimeMillis());
-//            System.out.println("ch="+jo.getAsJsonPrimitive("channel").getAsInt()
+//            System.out.println("ch="+jo.get("channel").getAsInt()
 //                +" endPipeline-startPipeline="
-//                  +(jo.getAsJsonPrimitive("endPipelineMsec").getAsLong()
-//                    - jo.getAsJsonPrimitive("startPipelineMsec").getAsLong())
+//                  +(jo.get("endPipelineMsec").getAsLong()
+//                    - jo.get("startPipelineMsec").getAsLong())
 //                +" exitParallel-startPipeine="
-//                  +(jo.getAsJsonPrimitive("exitParallelMsec").getAsLong()
-//                      - jo.getAsJsonPrimitive("startPipelineMsec").getAsLong()));
-//            int r = jo.getAsJsonPrimitive("result").getAsInt();
-//            assertEquals(splitter.applyAsInt(jo), jo.getAsJsonPrimitive("channel").getAsInt());
+//                  +(jo.get("exitParallelMsec").getAsLong()
+//                      - jo.get("startPipelineMsec").getAsLong()));
+//            int r = jo.get("result").getAsInt();
+//            assertEquals(splitter.applyAsInt(jo), jo.get("channel").getAsInt());
 //            return r;
 //          });
 //        

--- a/api/topology/src/test/java/quarks/test/topology/PlumbingTest.java
+++ b/api/topology/src/test/java/quarks/test/topology/PlumbingTest.java
@@ -610,8 +610,11 @@ public abstract class PlumbingTest extends TopologyAbstractTest {
         System.out.println(top.getName()+" chCounts="+Arrays.asList(chCounts));
         
         // a gross level performance check w/parallel channels
-        assertTrue("expMinSerialDuration="+expMinSerialDuration+" actDuration="+actDuration, 
-            actDuration < 0.5 * expMinSerialDuration);
+        if (Boolean.getBoolean("quarks.build.ci"))
+          System.err.println(top.getName()+" WARNING skipped performance check on 'ci' system use");
+        else
+          assertTrue("expMinSerialDuration="+expMinSerialDuration+" actDuration="+actDuration, 
+              actDuration < 0.5 * expMinSerialDuration);
         
         int evenChCounts = 0;
         int oddChCounts = 0;


### PR DESCRIPTION
- Add PlumbingStreams.parallelBalanced()
- Add LoadBalancedSplitter ToIntFunction
- Add testParallelBalanced()

Note: there's an oplet based implementation approach to a LoadBalancedSplitter that doesn't require "done" signaling nor separate ch "isolate()" use - one that has an internal thread pool pulling from single tuple queue.  Utilizing such a 1:n (~fanout) oplet would require adding something like ``TStream.split(Split)`` or perhaps ``TStream.addOp1N(oplet-with-one-input-and-N-output)``.

I'm sure there's a similar *functional* LoadBalancedSplitter possible and maybe I'll give that a little thought shortly.  Though, at this moment there's no way for Functions to get their hands on the Provider's thread pool nor receive explicit initialization.