### PR TITLE
[QUARKS-120] fix broken graph for "middle peek fanout" case

### DIFF
--- a/api/graph/src/main/java/quarks/graph/Connector.java
+++ b/api/graph/src/main/java/quarks/graph/Connector.java
@@ -82,7 +82,7 @@ public interface Connector<T> {
     void connect(Vertex<?, T, ?> target, int inputPort);
     
 	/**
-	 * Is my output port connected to any input port.
+	 * Was connect() called on this connector?
 	 * 
 	 * @return true if connected
 	 */

--- a/api/graph/src/main/java/quarks/graph/Graph.java
+++ b/api/graph/src/main/java/quarks/graph/Graph.java
@@ -77,13 +77,13 @@ public interface Graph {
     /**
      * Insert Peek oplets returned by the specified {@code Supplier} into 
      * the outputs of all of the oplets which satisfy the specified 
-     * {@code Predicate}.
+     * {@code Predicate} and where the output's {@link Connector#isConnected()}
+     * is true.
      * 
      * @param supplier
      *            Function which provides a Peek oplet to insert
      * @param select
-     *            Predicate to determine determines whether a Peek oplet will
-     *            be inserted on the outputs of the vertex passed as parameter
+     *            Vertex selection Predicate
      */
     void peekAll(Supplier<? extends Peek<?>> supplier, Predicate<Vertex<?, ?, ?>> select);
 

--- a/runtime/etiao/src/main/java/quarks/runtime/etiao/Invocation.java
+++ b/runtime/etiao/src/main/java/quarks/runtime/etiao/Invocation.java
@@ -193,4 +193,12 @@ public class Invocation<T extends Oplet<I, O>, I, O> implements AutoCloseable {
     public void close() throws Exception {
         oplet.close();
     }
+    
+    @Override
+    public String toString() {
+      return "{"
+          + "id=" + getId()
+          + " oplet=" + oplet.getClass().getSimpleName()
+          + "}";
+    }
 }

--- a/runtime/etiao/src/main/java/quarks/runtime/etiao/Invocation.java
+++ b/runtime/etiao/src/main/java/quarks/runtime/etiao/Invocation.java
@@ -194,6 +194,7 @@ public class Invocation<T extends Oplet<I, O>, I, O> implements AutoCloseable {
         oplet.close();
     }
     
+    /** For debug. Contents subject to change. */
     @Override
     public String toString() {
       return "{"

--- a/runtime/etiao/src/main/java/quarks/runtime/etiao/graph/EtiaoConnector.java
+++ b/runtime/etiao/src/main/java/quarks/runtime/etiao/graph/EtiaoConnector.java
@@ -59,7 +59,7 @@ class EtiaoConnector<P> implements Connector<P> {
     /** where to add the next peek and 1st connect() op */
     EtiaoConnector<P> activeConnector;
     
-    /** the non-peek or FanOut connect() added target */
+    /** the connect() added non-peek or FanOut target */
     Target<P> connectTarget;
     
     /** FanOut when the connector has >1 connect() added targets */
@@ -74,6 +74,7 @@ class EtiaoConnector<P> implements Connector<P> {
       return "{" 
           // avoid activeConnector.toString() recursion
           + " activeConnector=<" + activeConnector.oport + "," + activeConnector.vertex + ">"
+          + " primaryConnector=<" + primaryConnector.oport + "," + primaryConnector.vertex + ">"
           + " connectTarget=" + connectTarget
           + " fanOutVertex=" + fanOutVertex
           + " alias=" + alias
@@ -149,7 +150,7 @@ class EtiaoConnector<P> implements Connector<P> {
     ExecutableVertex<N, P, P> peekVertex = newInternalVertex(oplet, 1, 1);
     EtiaoConnector<P> peekConnector = peekVertex.getConnectors().get(0);
 
-    // The peek takes over the connection to connected target(s).
+    // The peek takes over the connection to connect() added target(s).
     if (isConnected()) {
       peekConnector.takeTarget();
     }
@@ -178,7 +179,7 @@ class EtiaoConnector<P> implements Connector<P> {
   }
 
   /**
-   * Disconnect the connected target(s)
+   * Disconnect the connect() added target(s)
    * @return the target
    */
   private Target<P> disconnectTarget() {
@@ -193,7 +194,7 @@ class EtiaoConnector<P> implements Connector<P> {
   }
 
   /**
-   * Take activeConnector's connection to the connected target(s).
+   * Take activeConnector's connection to the connect() added target(s).
    */
   private void takeTarget() {
     state.connectTarget = connectDirect(disconnectTarget());

--- a/runtime/etiao/src/main/java/quarks/runtime/etiao/graph/EtiaoConnector.java
+++ b/runtime/etiao/src/main/java/quarks/runtime/etiao/graph/EtiaoConnector.java
@@ -23,208 +23,241 @@ import java.util.HashSet;
 import java.util.Set;
 
 import quarks.graph.Connector;
-import quarks.graph.Edge;
 import quarks.graph.Vertex;
 import quarks.graph.spi.DirectEdge;
+import quarks.oplet.Oplet;
 import quarks.oplet.core.FanOut;
 import quarks.oplet.core.Peek;
 
 class EtiaoConnector<P> implements Connector<P> {
 
-	/**
-	 * The original port for this connector.
-	 */
-    private final ExecutableVertex<?, ?, P> originalVertex;
-	@SuppressWarnings("unused")
-    private final int originalPort;
-	private String alias;
+  /** The connector's associated vertex and its output port index. */
+  private final ExecutableVertex<?, ?, P> vertex;
+  private final int oport;
 
-	/**
-	 * The active port for this connector - where to add a peek or the 1st connect() target. 
-	 * active is different from original when
-	 * a peek has been inserted.  See commentary in peek().
-	 */
-	private ExecutableVertex<?, ?, P> activeVertex;
-	private int activePort;
+  /*
+   * The connector's shared state.
+   * 
+   * All of the connectors for a single logical stream share the same state.
+   * i.e., the connectors for the internally created peek and fanout vertices
+   * share their associated primary ("the stream's") connector's state.
+   */
+  private SharedState<P> state;
 
-	/* The connector's (non-peek) target. When connected this refers to
-	 * the 1st connect() target or a connect() injected FanOut.
-	 * See commentary in peek().
-	 */
-	private Target<P> target;
-
-	/**
-	 * Fanout vertex. When the output port is logically connected to multiple
-	 * inputs activeVertex will be connected to fanOutVertex and logical inputs
-	 * are connected to fanOutVertex.
-	 */
-    private ExecutableVertex<FanOut<P>, P, P> fanOutVertex;
-
-	public EtiaoConnector(ExecutableVertex<?, ?, P> originalVertex, int originalPort) {
-		this.originalVertex = originalVertex;
-		this.originalPort = originalPort;
-
-		this.activeVertex = originalVertex;
-		this.activePort = originalPort;
-
-    }
-
-    @Override
-	public DirectGraph graph() {
-        return activeVertex.graph();
-    }
-
-    @Override
-    public boolean isConnected() {
-    // See Connector.isConnected() doc for semantics
-		return target != null;
-    }
-
-    private boolean isFanOut() {
-        return fanOutVertex != null;
-    }
-
-	Target<P> disconnect() {
-		assert isConnected();
-
-		activeVertex.disconnect(activePort);
-		Target<P> target = this.target;
-		this.target = null;
-		assert !isConnected();
-		
-		return target;
-    }
-
-	/**
-	 * Take other's connection(s) leaving it disconnected.
-	 */
-	private void take(EtiaoConnector<P> other) {
-		connectDirect(other.disconnect());
-    }
-
-	private void connectDirect(Target<P> target) {
-		assert !isConnected();
-		
-        activeVertex.connect(activePort, target, newEdge(target));
-		this.target = target;
-	}
-
-    @Override
-    public void connect(Vertex<?, P, ?> target, int targetPort) {
-		if (!isConnected()) {
-
-			connectDirect(new Target<>((ExecutableVertex<?, P, ?>) target, targetPort));
-			return;
-        }
-
-		if (!isFanOut()) {
-
-            // Insert a FanOut oplet, initially with a single output port
-			fanOutVertex = graph().insert(new FanOut<P>(), 1, 1);
-            
-            // Connect the FanOut's first port to the previous target
-            EtiaoConnector<P> fanOutConnector = fanOutVertex.getConnectors().get(0);
-            fanOutConnector.take(this);
-            
-			// Connect this to the FanOut oplet
-			assert !isConnected();
-            connect(fanOutVertex, 0);
-        }
-
-        // Add another output port to the fan out oplet.
-        Connector<P> fanOutConnector = fanOutVertex.addOutput();
-        fanOutConnector.connect(target, targetPort);
-    }
-
-    @Override
-    public <N extends Peek<P>> Connector<P> peek(N oplet) {
-        /*
-			   * See Connector.peek() method/class doc for semantics.
-				 * A peek is added at the activeVertex/port and
-				 * then becomes the new activeVertex/port.
-         * 
-         * Adding a peek must not change whether or not the
-         * "primary" connector "is connected" / has a target.
-				 * The new peek does not become the "target".
-         * 
-         * The net is a peekConnector's target is always null
-				 * and its activeVertex is always its originalVertex.
-         */
-        ExecutableVertex<N, P, P> peekVertex = graph().insert(oplet, 1, 1);
-
-        // Have the output of the peek take over the connections of the current output.
-        EtiaoConnector<P> peekConnector = peekVertex.getConnectors().get(0);
-
-        if (isConnected()) {
-            // N.B. "take" is designed for normal (non-peek) use - it fully
-            // dissociates "other" from its connected target and then fully
-            // associates the connector with the target.  Perfect when
-            // doing something like injecting a FanOut.
-            // 
-            // However, for injecting a peek, peekConnector incorrectly
-            // ends up inheriting "this"'s target and "this" is no longer
-            // "connected" to the target as it should / must be.
-          
-            peekConnector.take(this);
-            
-            // put the target back the way it must be
-            target = peekConnector.target;
-            peekConnector.target = null;
-        }
-        
-        // Connect to the new peek from our active vertex and
-        // extend the activeVertex to be the new peek.
-        //
-        // DO NOT change this connector's target - it remains connected or not
-        // independent of peeks.
-        
-        Target<P> target = new Target<P>(peekVertex, 0);
-        activeVertex.connect(activePort, target, newEdge(target));
-
-        activeVertex = peekVertex;
-        activePort = 0;
-
-        return this;
-    }
-
-	private Edge newEdge(Target<?> target) {
-	    return new DirectEdge(this, activeVertex, activePort, target.vertex, target.port);
-	}
-
+  /**
+   * Shared connector state.
+   * 
+   * @param <P> The Input/Output port type.
+   */
+  private static class SharedState<P> {    
+    String alias;
     private Set<String> tags = new HashSet<>();
+    
+    /** the primary ("the stream's") connector */
+    EtiaoConnector<P> primaryConnector;
+    
+    /** where to add the next peek and 1st connect() op */
+    EtiaoConnector<P> activeConnector;
+    
+    /** the non-peek or FanOut connect() added target */
+    Target<P> connectTarget;
+    
+    /** FanOut when the connector has >1 connect() added targets */
+    ExecutableVertex<FanOut<P>, P, P> fanOutVertex;
 
-    @Override
-    public void tag(String... values) {
-        for (String v : values)
-            tags.add(v);
+    public SharedState(EtiaoConnector<P> connector) {
+      primaryConnector = connector;
+      activeConnector = connector;
     }
 
-    @Override
-    public Set<String> getTags() {
-        return Collections.unmodifiableSet(tags);
+    public String toString() {
+      return "{" 
+          // avoid activeConnector.toString() recursion
+          + " activeConnector=<" + activeConnector.oport + "," + activeConnector.vertex + ">"
+          + " connectTarget=" + connectTarget
+          + " fanOutVertex=" + fanOutVertex
+          + " alias=" + alias
+          + " tags=" + tags
+          + "}";
+    }
+  }
+
+  /**
+   * Create a new connector.
+   * 
+   * @param vertex the connector's associated Vertex
+   * @param oport the connector's output port index
+   */
+  public EtiaoConnector(ExecutableVertex<?, ?, P> vertex, int oport) {
+    this.vertex = vertex;
+    this.oport = oport;
+    this.state = new SharedState<P>(this); // later reset for "internal" connectors
+  }
+
+  @Override
+  public DirectGraph graph() {
+    return vertex.graph();
+  }
+
+  @Override
+  public boolean isConnected() {
+    // see Connector.isConnected() doc for semantics
+    // the primary connector can return true.  
+    // internal peek connectors must return false (peekAll() depends on it)
+    // internal fanout connectors return false (used to be true and peekAll()
+    //    callers had to explicitly exclude fanout ops).
+   
+    return state.connectTarget != null && this == state.primaryConnector;
+  }
+
+  private boolean isFanOut() {
+    return state.fanOutVertex != null;
+  }
+
+  @Override
+  public void connect(Vertex<?, P, ?> target, int targetPort) {
+    // to be used only for connecting to non-internal (non peek/fanout) vertex
+    
+    if (!isConnected()) {  // 1st connect()
+      state.connectTarget = connectActiveDirect(new Target<P>((ExecutableVertex<?, P, ?>) target, targetPort));
+      return;
     }
 
-    @Override
-    public void alias(String alias) {
-        if (this.alias != null)
-            throw new IllegalStateException("alias already set");
-        this.alias = alias;
-    }
+    if (!isFanOut()) {  // 2nd connect()
+      // Add a FanOut oplet, initially with a single output port
+      // connected to 1st connect()'s target
+      state.fanOutVertex = newInternalVertex(new FanOut<P>(), 1, 1);
+      EtiaoConnector<P> fanOutConnector = state.fanOutVertex.getConnectors().get(0);
+      fanOutConnector.takeTarget();
 
-    @Override
-    public String getAlias() {
-        return alias;
+      // Connect to the FanOut oplet. The FanOut becomes the connectTarget.
+      state.connectTarget = connectActiveDirect(new Target<P>(state.fanOutVertex, 0));
     }
     
-    /**
-     * Intended only as a debug aid and content is not guaranteed. 
-     */
-    @Override
-    public String toString() {
-        return getClass().getSimpleName()
-                + " activePort=" + activePort
-                + " alias=" + getAlias()
-                + " tags=" + getTags();
+    // 2nd-nth connect(): add target as another connector/connection from the FanOut
+    EtiaoConnector<P> fanOutConnector = state.fanOutVertex.addOutput();
+    fanOutConnector.state = state;
+    fanOutConnector.connectDirect(new Target<P>((ExecutableVertex<?, P, ?>) target, targetPort));
+    
+    assert isConnected();
+  }
+
+  @Override
+  public <N extends Peek<P>> Connector<P> peek(N oplet) {
+    // see Connector.peek() method/class doc for the semantics
+    
+    ExecutableVertex<N, P, P> peekVertex = newInternalVertex(oplet, 1, 1);
+    EtiaoConnector<P> peekConnector = peekVertex.getConnectors().get(0);
+
+    // The peek takes over the connection to connected target(s).
+    if (isConnected()) {
+      peekConnector.takeTarget();
     }
+
+    // Connect to the new peek.  It becomes the activeConnector / new addition point.
+    connectActiveDirect(new Target<P>(peekVertex, 0));
+    state.activeConnector = peekConnector;
+
+    return this;
+  }
+
+  /**
+   * Create a new vertex for internal use (with shared connector state)
+   * @param op a Peek or FanOut oplet
+   * @param nInputs number of input ports
+   * @param nOutputs number of output ports
+   * @return the new vertex
+   */
+  private <N extends Oplet<P, P>> ExecutableVertex<N, P, P> 
+  newInternalVertex(N op, int nInputs, int nOutputs) {
+    ExecutableVertex<N, P, P> vertex = graph().insert(op, nInputs, nOutputs);
+    for (EtiaoConnector<P> connector : vertex.getConnectors()) {
+      connector.state = state;
+    }
+    return vertex;
+  }
+
+  /**
+   * Disconnect the connected target(s)
+   * @return the target
+   */
+  private Target<P> disconnectTarget() {
+    assert state.connectTarget != null;
+
+    state.activeConnector.vertex.disconnect(state.activeConnector.oport);
+    Target<P> target = state.connectTarget;
+    state.connectTarget = null;
+    assert state.connectTarget == null;
+
+    return target;
+  }
+
+  /**
+   * Take activeConnector's connection to the connected target(s).
+   */
+  private void takeTarget() {
+    state.connectTarget = connectDirect(disconnectTarget());
+  }
+
+  /**
+   * Connect this to the target
+   * @param target
+   * @return the target parameter
+   */
+  private Target<P> connectDirect(Target<P> target) {
+    vertex.connect(oport, target,
+        new DirectEdge(this, vertex, oport, target.vertex, target.port));
+    return target;
+  }
+
+  /**
+   * Connect the activeConnector to the target
+   * @param target
+   * @return the target parameter
+   */
+  private Target<P> connectActiveDirect(Target<P> target) {
+    ExecutableVertex<?,?,P> vertex = state.activeConnector.vertex;
+    int oport = state.activeConnector.oport;
+    vertex.connect(oport, target, 
+        new DirectEdge(state.activeConnector,
+            vertex, oport, target.vertex, target.port));
+    return target;
+  }
+
+  @Override
+  public void tag(String... values) {
+    for (String v : values)
+      state.tags.add(v);
+  }
+
+  @Override
+  public Set<String> getTags() {
+    return Collections.unmodifiableSet(state.tags);
+  }
+
+  @Override
+  public void alias(String alias) {
+    if (state.alias != null)
+      throw new IllegalStateException("alias already set");
+    state.alias = alias;
+  }
+
+  @Override
+  public String getAlias() {
+    return state.alias;
+  }
+
+  /**
+   * Intended only as a debug aid and content is not guaranteed.
+   */
+  @Override
+  public String toString() {
+    return "{"
+        + getClass().getSimpleName()
+        + " oport=" + oport
+        + " vertex=" + vertex
+        + " state=" + state 
+        + "}";
+  }
 
 }

--- a/runtime/etiao/src/main/java/quarks/runtime/etiao/graph/ExecutableVertex.java
+++ b/runtime/etiao/src/main/java/quarks/runtime/etiao/graph/ExecutableVertex.java
@@ -134,4 +134,13 @@ public class ExecutableVertex<N extends Oplet<C, P>, C, P> extends AbstractVerte
         }
         return Collections.unmodifiableList(connectedEdges);
     }
+    
+    /** For debug. Contents subject to change. */
+    @Override
+    public String toString() {
+      return "{" 
+          + "invocation=" + invocation
+          // + " edges=" + edges
+          + "}";
+    }
 }

--- a/runtime/etiao/src/main/java/quarks/runtime/etiao/graph/Target.java
+++ b/runtime/etiao/src/main/java/quarks/runtime/etiao/graph/Target.java
@@ -27,4 +27,13 @@ class Target<T> {
 	}
 	final ExecutableVertex<?, T, ?> vertex;
 	final int port;
+	
+// /** For debug. Contents subject to change. */
+//	@Override
+//	public String toString() {
+//	  return "{"
+//	      + "port=" + port
+//	      + " vertex=" + vertex
+//	      + "}";
+//	}
 }

--- a/spi/graph/src/main/java/quarks/graph/spi/AbstractGraph.java
+++ b/spi/graph/src/main/java/quarks/graph/spi/AbstractGraph.java
@@ -24,7 +24,6 @@ import java.util.List;
 import quarks.function.Predicate;
 import quarks.function.Supplier;
 import quarks.graph.Connector;
-import quarks.graph.Edge;
 import quarks.graph.Graph;
 import quarks.graph.Vertex;
 import quarks.oplet.Oplet;
@@ -32,37 +31,16 @@ import quarks.oplet.core.Peek;
 import quarks.oplet.core.Source;
 
 /**
- * Placeholder for a skeletal implementation of the {@link Graph} interface,
+ * A skeletal implementation of the {@link Graph} interface,
  * to minimize the effort required to implement the interface.
  */
 public abstract class AbstractGraph<G> implements Graph {
-    /**
-     * Create a new unconnected {@link Vertex} associated with the
-     * specified source {@link Oplet}.
-     * 
-     * 
-     * <p>
-     * The {@code Vertex} for the oplet has 0 input connectors and one output connector.
-     * @param oplet the source oplet
-     * @return the output connector for the newly created vertex.
-     */
+ 
     @Override
     public <N extends Source<P>, P> Connector<P> source(N oplet) {
         return insert(oplet, 0, 1).getConnectors().get(0);
     }
 
-    /**
-     * Create a new connected {@link Vertex} associated with the
-     * specified {@link Oplet}.
-     * <p>
-     * The new {@code Vertex} has one input and one output {@code Connector}.
-     * An {@link Edge} is created connecting the specified output connector to
-     * the new vertice's input connector.
-     * 
-     * @param output
-     * @param oplet the oplet to associate with the new {@code Vertex}
-     * @return the output connector for the new {@code Vertex}
-     */
     @Override
     public <N extends Oplet<C, P>, C, P> Connector<P> pipe(Connector<C> output, N oplet) {
         Vertex<N, C, P> pipeVertex = insert(oplet, 1, 1);
@@ -71,17 +49,6 @@ public abstract class AbstractGraph<G> implements Graph {
         return pipeVertex.getConnectors().get(0);
     }
 
-    /**
-     * Insert Peek oplets returned by the specified {@code Supplier} into 
-     * the outputs of all of the oplets which satisfy the specified 
-     * {@code Predicate}.
-     * 
-     * @param supplier
-     *            Function which provides a Peek oplet to insert
-     * @param select
-     *            Predicate to determine determines whether a Peek oplet will
-     *            be inserted on the outputs of the vertex passed as parameter
-     */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public void peekAll(Supplier<? extends Peek<?>> supplier, Predicate<Vertex<?, ?, ?>> select) {
@@ -92,7 +59,7 @@ public abstract class AbstractGraph<G> implements Graph {
                 vertices.add(v);
             }
         }
-        // Insert metric oplets
+        // Insert peek oplets on isConnected() output ports
         for (Vertex<?, ?, ?> v : vertices) {
             List<? extends Connector<?>> connectors = v.getConnectors();
             for (Connector<?> c : connectors) {

--- a/spi/graph/src/main/java/quarks/graph/spi/DirectEdge.java
+++ b/spi/graph/src/main/java/quarks/graph/spi/DirectEdge.java
@@ -88,4 +88,15 @@ public class DirectEdge implements Edge {
     public String getAlias() {
         return connector.getAlias();
     }
+    
+//    /** For debug. Contents subject to change. */
+//    @Override
+//    public String toString() {
+//      return "{"
+//          + "source=" + (source==null ? "null" : source.getInstance())
+//          + " sourcePort=" + sourcePort
+//          + " target=" + (target==null ? "null" : target.getInstance())
+//          + " targetPort=" + targetPort
+//          + "}";
+//    }
 }

--- a/utils/metrics/src/main/java/quarks/metrics/Metrics.java
+++ b/utils/metrics/src/main/java/quarks/metrics/Metrics.java
@@ -18,7 +18,7 @@ under the License.
 */
 package quarks.metrics;
 
-import quarks.graph.Vertex;
+import quarks.function.Functions;
 import quarks.metrics.oplets.CounterOp;
 import quarks.metrics.oplets.RateMeter;
 import quarks.topology.TStream;
@@ -63,15 +63,14 @@ public class Metrics {
      * <li>If a chain a Peek oplets is followed by a FanOut, a metric oplet is 
      * inserted between the last Peek and the FanOut oplet.</li>
      * </ul>
-     * The implementation is not idempotent: previously inserted metric oplets
-     * are treated as regular graph vertices.  Calling the method twice 
+     * The implementation is not idempotent: Calling the method twice 
      * will insert a new set of metric oplets into the graph.
      * @param t
      *            The topology
+     * @see quarks.graph.Graph#peekAll(quarks.function.Supplier, quarks.function.Predicate) Graph.peekAll()
      */
     public static void counter(Topology t) {
-        t.graph().peekAll( 
-                () -> new CounterOp<>(),
-                (Vertex<?, ?, ?> v) -> !(v.getInstance() instanceof quarks.oplet.core.FanOut));
+        // peekAll() embodies the above exclusion semantics
+        t.graph().peekAll(() -> new CounterOp<>(), Functions.alwaysTrue());
     }
 }

--- a/utils/streamscope/src/main/java/quarks/streamscope/StreamScopeSetup.java
+++ b/utils/streamscope/src/main/java/quarks/streamscope/StreamScopeSetup.java
@@ -20,8 +20,7 @@ package quarks.streamscope;
 
 import quarks.execution.services.ControlService;
 import quarks.execution.services.ServiceContainer;
-import quarks.graph.Vertex;
-import quarks.oplet.core.Peek;
+import quarks.function.Functions;
 import quarks.streamscope.mbeans.StreamScopeRegistryMXBean;
 import quarks.topology.Topology;
 import quarks.topology.TopologyProvider;
@@ -187,6 +186,7 @@ public class StreamScopeSetup {
      * @param t the Topology.  The operation is a no-op if the topology
      *     does not have a StreamScopeRegistry service.
      * @see #register(ServiceContainer) register
+     * @see quarks.graph.Graph#peekAll(quarks.function.Supplier, quarks.function.Predicate) Graph.peekAll()
      */
     public static void addStreamScopes(Topology t) {
       StreamScopeRegistry rgy = (StreamScopeRegistry) 
@@ -220,12 +220,8 @@ public class StreamScopeSetup {
       // TODO straighten this all out
 
       t.graph().peekAll( 
-          () -> {
-              StreamScope<?> streamScope = new StreamScope<>();
-              Peek<?> peekOp = new quarks.streamscope.oplets.StreamScope<>(streamScope);
-              return peekOp;
-            },
-          (Vertex<?, ?, ?> v) -> !(v.getInstance() instanceof quarks.oplet.core.FanOut));
+          () -> { return new quarks.streamscope.oplets.StreamScope<>(new StreamScope<>()); },
+          Functions.alwaysTrue());
     }
 
 }


### PR DESCRIPTION
- fix the case
  - this is an incremental ~minimal change fix. It feels a bit hacky and
doesn't address some other concerns with the EtiaoConnector.
- enhance tests to include the case
- clarify Connector.isConnect()'s existing semantics