### PR TITLE
[QUARKS-197] tweak test's timing for intermittent failures

### DIFF
--- a/analytics/sensors/src/test/java/quarks/test/analytics/sensors/FiltersTest.java
+++ b/analytics/sensors/src/test/java/quarks/test/analytics/sensors/FiltersTest.java
@@ -194,7 +194,7 @@ public class FiltersTest  extends TopologyAbstractTest implements DirectTestSetu
             }
             else if (curCnt == 7) {
                 // lengthen deadtime, so should now exclude 8 too and then 10
-                deadtime.setPeriod(300, TimeUnit.MILLISECONDS);
+                deadtime.setPeriod(250, TimeUnit.MILLISECONDS);
             }
             return curCnt;
             }, 100, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
got a couple of failures where 1,4,6,10 was received instead of 1,4,6,9.
Think the deadtime change was a bit too long so 9 wasn't outside of the
time-band.