### PR TITLE
Add IntelliJ Idea file extension to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,5 @@ hs_err_pid*
 build/
 
 # IntelliJ Idea
-.idea
+.idea/
 *.iml

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ hs_err_pid*
 
 /.gradle/
 build/
+
+# IntelliJ Idea
+.idea
+*.iml


### PR DESCRIPTION
I mainly use the IntelliJ Idea, so I think it will be helpful if gitignore including an IntelliJ file extensions.