### PR TITLE
[QUARKS-223] Junit parity

### DIFF
--- a/api/topology/build.gradle
+++ b/api/topology/build.gradle
@@ -18,12 +18,16 @@ dependencies {
   compile ext_classpath
 }
 
-
-jar {
-  configure jarOptions
-  jar.includeEmptyDirs = false
-  destinationDir = sourceSets.test.output.classesDir
-  archiveName = "edgent.api.topology.APPS.TEST.jar"
-  //from sourceSets.main.output.classesDir
-  //include 'quarks.test.topology.services.TestApplications$AppOne'
+//Build a jar file containing the applications to test the ApplicationService
+task testApplicationJar{
+  ant.jar(destfile: "test.classes/edgent.api.topology.APPS.TEST.jar") {
+    service(type: 'org.apache.edgent.topology.services.TopologyBuilder') {
+      provider(classname: 'org.apache.edgent.test.topology.services.TestApplications$AppOne')
+      provider(classname: 'org.apache.edgent.test.topology.services.TestApplications$AppTwo')
+      provider(classname: 'org.apache.edgent.test.topology.services.TestApplications$AppThree')
+    }
+    fileset (dir: 'test.classes', includes: '**/*TestApplications$App*.class')
+  }
 }
+
+testClasses.dependsOn testApplicationJar

--- a/api/topology/build.gradle
+++ b/api/topology/build.gradle
@@ -17,3 +17,13 @@ dependencies {
   compile project(':api:oplet')
   compile ext_classpath
 }
+
+
+jar {
+  configure jarOptions
+  jar.includeEmptyDirs = false
+  destinationDir = sourceSets.test.output.classesDir
+  archiveName = "edgent.api.topology.APPS.TEST.jar"
+  //from sourceSets.main.output.classesDir
+  //include 'quarks.test.topology.services.TestApplications$AppOne'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -89,14 +89,6 @@ subprojects {
     configure compileOptions
   }
 
-  test {
-    include '**/*Test.class'
-    systemProperty 'edgent.test.top.dir.file.path', rootProject.projectDir
-    testLogging {
-      exceptionFormat 'full'
-    }
-  }
-
   ext.jarOptions = {
     manifest {
       attributes(
@@ -144,12 +136,11 @@ subprojects {
   build.dependsOn copyJar
 }
 
-task consoleWar (dependsOn: "console:servlets"){
-  copy {
-    includeEmptyDirs = false
-    from "${project("console:servlets").buildDir}"
-    into "${rootProject.ext.target_java8_dir}/console/"
-    include "**/*.war"
+test {
+  include '**/*Test.class'
+  systemProperty 'edgent.test.top.dir.file.path', rootProject.projectDir
+  testLogging {
+    exceptionFormat 'full'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,16 @@ subprojects {
     configure compileOptions
   }
 
+  test {
+    include '**/*Test.class'
+
+    systemProperty 'edgent.test.top.dir.file.path', rootProject.projectDir
+    systemProperty 'edgent.test.root.dir', rootProject.projectDir
+    testLogging {
+      exceptionFormat 'full'
+    }
+  }
+
   ext.jarOptions = {
     manifest {
       attributes(
@@ -134,14 +144,6 @@ subprojects {
 
   copyJar.dependsOn assemble
   build.dependsOn copyJar
-}
-
-test {
-  include '**/*Test.class'
-  systemProperty 'edgent.test.top.dir.file.path', rootProject.projectDir
-  testLogging {
-    exceptionFormat 'full'
-  }
 }
 
 task copyScript {

--- a/console/server/src/main/java/org/apache/edgent/console/server/ServerUtil.java
+++ b/console/server/src/main/java/org/apache/edgent/console/server/ServerUtil.java
@@ -79,7 +79,7 @@ public class ServerUtil {
         } catch (IOException e) {
           // end of file searching
         }
-        if (foundFiles.size() == 1) {
+        if (foundFiles.size() != 0) {
             return foundFiles.get(0);
         }
         return null;

--- a/console/servlets/build.gradle
+++ b/console/servlets/build.gradle
@@ -34,3 +34,5 @@ war {
   }
   webXml = file('webapp_content/WEB-INF/console.xml')
 }
+
+testClasses.dependsOn war

--- a/providers/direct/build.gradle
+++ b/providers/direct/build.gradle
@@ -21,8 +21,6 @@ dependencies {
   compile ext_classpath
   testCompile project(':utils:metrics')
   testCompile project(':runtime:appservice')
-  testCompile files('edgent.api.topology.APPS.TEST.jar')
 }
 
 addCompileTestDependencies ':api:topology', ':utils:metrics', ':runtime:appservice'
-

--- a/providers/direct/build.gradle
+++ b/providers/direct/build.gradle
@@ -21,6 +21,8 @@ dependencies {
   compile ext_classpath
   testCompile project(':utils:metrics')
   testCompile project(':runtime:appservice')
+  testCompile files('edgent.api.topology.APPS.TEST.jar')
 }
 
 addCompileTestDependencies ':api:topology', ':utils:metrics', ':runtime:appservice'
+


### PR DESCRIPTION
- I'm working on but little more testing needed
- I did not want to call the ant.jar in gradle but was unable to add the file to the META-INF/service. Please teach me if anyone has a good idea.
- I modified ServerUtil.java to avoid error when there are 2 or more console.war(in webapp directory) but does not looks good. I think this remainning in a temporarily until @dlaboss 's work