### PR TITLE
Quarks-205 fix gradle broken javadoc doc-files links

### DIFF
--- a/api/execution/src/main/java/org/apache/edgent/execution/services/RuntimeServices.java
+++ b/api/execution/src/main/java/org/apache/edgent/execution/services/RuntimeServices.java
@@ -43,7 +43,6 @@ package org.apache.edgent.execution.services;
  * }
  * </code>
  * </pre>
- * </P>
  *
  */
 public interface RuntimeServices {

--- a/build.gradle
+++ b/build.gradle
@@ -181,6 +181,16 @@ task aggregateJavadoc(type: Javadoc) {
   classpath = files(subprojects.collect
           { project -> project.sourceSets.main.compileClasspath }
   )
+  
+  // doc-files aren't picked up automatically so get them now.
+  doLast {
+    copy {
+      from subprojects.collect { project -> project.sourceSets.main.java.srcDirs }
+      include '**/doc-files/**'
+      includeEmptyDirs = false
+      into "$rootProject.ext.target_javadoc_dir"
+    }
+  }
 }
 
 build.dependsOn aggregateJavadoc

--- a/connectors/command/src/main/java/org/apache/edgent/connectors/command/runtime/CommandReader.java
+++ b/connectors/command/src/main/java/org/apache/edgent/connectors/command/runtime/CommandReader.java
@@ -30,8 +30,8 @@ import org.apache.edgent.function.Supplier;
  * and restart it upon process termination/error if so configured.
  * </P>
  * <P>
- * The iterator returned by {@link Iterable#iterator()) returns
- * {@hasNext()==true} until a read from {@link Process#getOutputStream()}
+ * The iterator returned by {@link Iterable#iterator()} returns
+ * {@code hasNext()==true} until a read from {@link Process#getOutputStream()}
  * returns EOF or an IOError.
  */
 public class CommandReader extends CommandConnector implements Supplier<Iterable<String>>, AutoCloseable {


### PR DESCRIPTION
- Explicitly pickup doc-files files to fix topology/package-info:"Edgent
Source Streams" link and analytics/sensors/Filters:"Deadband example"
link
- cleanup two javadoc warnings/errors