### PR TITLE
Quarks-205 fix gradle generated overview javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,12 +168,12 @@ task aggregateJavadoc(type: Javadoc) {
     overview "edgent_overview.html"
     windowTitle "Edgent v${build_version}"
 
-    group("Edgent API", "org.apache.edgent.execution", "org.apache.edgent.function", "org.apache.edgent.topology", "org.apache.edgent.topology.json", "org.apache.edgent.topology.mbeans", "org.apache.edgent.topology.plumbing", "org.apache.edgent.topology.services", "org.apache.edgent.execution.*")
     group("Edgent Providers", "org.apache.edgent.providers.*")
-    group("Edgent Connectors", "org.apache.edgent.connectors.*")
-    group("Edgent Samples", "org.apache.edgent.samples.*")
+    group("Edgent API", "org.apache.edgent.execution", "org.apache.edgent.function", "org.apache.edgent.topology", "org.apache.edgent.topology.json", "org.apache.edgent.topology.mbeans", "org.apache.edgent.topology.plumbing", "org.apache.edgent.topology.services", "org.apache.edgent.execution.*")
     group("Edgent Analytics", "org.apache.edgent.analytics.*")
     group("Edgent Utilities", "org.apache.edgent.metrics", "org.apache.edgent.metrics.*", "org.apache.edgent.streamscope", "org.apache.edgent.streamscope.*")
+    group("Edgent Connectors", "org.apache.edgent.connectors.*")
+    group("Edgent Samples", "org.apache.edgent.samples.*")
     group("Edgent Low-Level API", "org.apache.edgent.graph", "org.apache.edgent.graph.*", "org.apache.edgent.oplet", "org.apache.edgent.oplet.*", "org.apache.edgent.window")
     group("Edgent SPI", "org.apache.edgent.topology.spi", "org.apache.edgent.topology.spi.*")
   }
@@ -181,6 +181,11 @@ task aggregateJavadoc(type: Javadoc) {
   classpath = files(subprojects.collect
           { project -> project.sourceSets.main.compileClasspath }
   )
+  // Eliminate implementation packages/classes from the javadoc.
+  // TODO achieve the effect w/o causing warnings from the javadoc run
+  exclude "**/edgent/connectors/**/runtime"
+  exclude "**/edgent/console"
+  exclude "**/edgent/samples/scenarios/iotp/range/sensor"
   
   // doc-files aren't picked up automatically so get them now.
   doLast {

--- a/edgent_overview.html
+++ b/edgent_overview.html
@@ -109,7 +109,7 @@ However Edgent allows arbitrary topologies including:
 <LI>Multiple sinks in an application </LI>
 <LI>Multiple processing including sinks against a stream (fan-out)</LI>
 <LI>Union of streams (fan-in)  </LI>
-<LI>Correlation of streams by allowing streams to be joined (to be added)</LI>
+<LI>Correlation of streams by allowing streams to be joined</LI>
 </UL>
 <H3>Graph API</H3>
 <H4>Overview</H4>
@@ -196,8 +196,10 @@ Feel free to explore them.
 You need to include one or more Edgent jars in your {@code classpath} depending
 on what features your application uses.
 <P>
-Include one or both of the following:
+Include one or more of the topology providers:
 <ul>
+<li>{@code <edgent-target>/lib/edgent.providers.iot.jar} - if you use the
+{@link org.apache.edgent.providers.iot.IotProvider IotProvider}</li>
 <li>{@code <edgent-target>/lib/edgent.providers.direct.jar} - if you use the
 {@link org.apache.edgent.providers.direct.DirectProvider DirectProvider}</li>
 <li>{@code <edgent-target>/lib/edgent.providers.development.jar} - if you use the
@@ -205,11 +207,15 @@ Include one or both of the following:
 </ul>
 Include the jar of any Edgent connector you use:
 <ul>
+<li>{@code <edgent-target>/connectors/command/lib/edgent.connectors.command.jar}</li>
+<li>{@code <edgent-target>/connectors/csv/lib/edgent.connectors.csv.jar}</li>
 <li>{@code <edgent-target>/connectors/file/lib/edgent.connectors.file.jar}</li>
+<li>{@code <edgent-target>/connectors/http/lib/edgent.connectors.http.jar}</li>
+<li>{@code <edgent-target>/connectors/iotp/lib/edgent.connectors.iotp.jar}</li>
 <li>{@code <edgent-target>/connectors/jdbc/lib/edgent.connectors.jdbc.jar}</li>
-<li>{@code <edgent-target>/connectors/iotf/lib/edgent.connectors.iotf.jar}</li>
 <li>{@code <edgent-target>/connectors/kafka/lib/edgent.connectors.kafka.jar}</li>
 <li>{@code <edgent-target>/connectors/mqtt/lib/edgent.connectors.mqtt.jar}</li>
+<li>{@code <edgent-target>/connectors/pubsub/lib/edgent.connectors.pubsub.jar}</li>
 <li>{@code <edgent-target>/connectors/wsclient-javax.websocket/lib/edgent.connectors.wsclient.javax.websocket.jar} [*]</li>
 </ul>
 [*] You also need to include a {@code javax.websocket} client implementation

--- a/utils/streamscope/src/main/java/org/apache/edgent/streamscope/oplets/package-info.java
+++ b/utils/streamscope/src/main/java/org/apache/edgent/streamscope/oplets/package-info.java
@@ -1,0 +1,23 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+/**
+ * Stream Oscilloscope underlying implementation oplets.
+ */
+package org.apache.edgent.streamscope.oplets;


### PR DESCRIPTION
- fix for iotf to iotp rename
- tweak directions for building applications for new iot provider and
new connectors
- tweak overview doc now that "join" exists
- reorder overview's javadoc categories
- eliminate connectors/**/runtime, and some others, from generated
javadoc (parity with ant builds)